### PR TITLE
fix: Fixed register endpoint as a permited URL, refactor on WebClient…

### DIFF
--- a/src/main/java/com/cepsearch/cep_search_application/config/JWTConfiguration.java
+++ b/src/main/java/com/cepsearch/cep_search_application/config/JWTConfiguration.java
@@ -52,6 +52,7 @@ public class JWTConfiguration {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, "/login").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/user/create").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilter(jwtAuthFilter)

--- a/src/main/java/com/cepsearch/cep_search_application/config/WebClientConfiguration.java
+++ b/src/main/java/com/cepsearch/cep_search_application/config/WebClientConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
-public class WebClientConfig {
+public class WebClientConfiguration {
 
     @Value("${cep.api.url}")
     private String baseUrl;


### PR DESCRIPTION
### Fixed

- Added the register endpoint (POST - > "/api/user/create") as a permited endpoint, without token authorization
- Refactor on WebClient configuration class: WebClientConfig.java -> WebClientConfiguration.java